### PR TITLE
Adding pytests for methods

### DIFF
--- a/test_get_closest_station.py
+++ b/test_get_closest_station.py
@@ -1,0 +1,23 @@
+
+import pytest
+import requests
+from high_low_temps_by_address import get_closest_station
+
+# Should return the correct station ID when given valid latitude and longitude
+def test_valid_latitude_longitude():
+    latitude = 39.7392
+    longitude = -104.9903
+    expected_station_id = 'KBJC'
+    
+    result = get_closest_station(latitude, longitude)
+    
+    assert result == expected_station_id
+
+# Should return None when given invalid latitude and longitude
+def test_invalid_latitude_longitude():
+    latitude = 100
+    longitude = -200
+    
+    result = get_closest_station(latitude, longitude)
+    
+    assert result == None

--- a/test_get_geolocation.py
+++ b/test_get_geolocation.py
@@ -1,0 +1,50 @@
+import pytest
+import requests
+from high_low_temps_by_address import get_geolocation
+
+# Given a valid US address, it should return the latitude and longitude of the address
+def test_valid_address(mocker):
+    # Mock the requests.get() function to return a predefined response
+    mocker.patch('requests.get')
+    requests.get.return_value.json.return_value = {
+        'result': {
+            'addressMatches': [
+                {
+                    'coordinates': {
+                        'y': 39.7392,
+                        'x': -104.9903
+                    }
+                }
+            ]
+        }
+    }
+    # Call the code under test
+    result = get_geolocation('1701 Wynkoop St. Denver, CO')
+    # Assert the result is the expected latitude and longitude
+    assert result == (39.7392, -104.9903)
+    # Assert that requests.get() was called with the correct URL and parameters
+    requests.get.assert_called_once_with('https://geocoding.geo.census.gov/geocoder/locations/onelineaddress', {
+        'address': '1701 Wynkoop St. Denver, CO',
+        'benchmark': 'Public_AR_Current',
+        'format': 'json'
+    })
+
+# Given an invalid US address, it should raise an exception
+def test_invalid_address(mocker):
+    # Mock the requests.get() function to return a predefined response with no address matches
+    mocker.patch('requests.get')
+    requests.get.return_value.json.return_value = {
+        'result': {
+            'addressMatches': []
+        }
+    }   
+    # Call the code under test
+    with pytest.raises(Exception):
+        get_geolocation('Invalid Address')
+    
+    # Assert that requests.get() was called with the correct URL and parameters
+    requests.get.assert_called_once_with('https://geocoding.geo.census.gov/geocoder/locations/onelineaddress', {
+        'address': 'Invalid Address',
+        'benchmark': 'Public_AR_Current',
+        'format': 'json'
+    })

--- a/test_get_high_low_temps_by_day.py
+++ b/test_get_high_low_temps_by_day.py
@@ -1,0 +1,75 @@
+import pytest
+import requests
+from datetime import datetime
+from high_low_temps_by_address import get_high_low_temps_by_day
+
+# Should return a dictionary with high and low temperatures for each day
+def test_return_high_low_temps(mocker):
+    # Mock the response from the API
+    mocker.patch('requests.get')
+    response_mock = mocker.Mock()
+    response_mock.json.return_value = {
+        'features': [
+            {
+                'properties': {
+                    'timestamp': '2022-01-01T00:00:00+00:00',
+                    'temperature': {'value': 10}
+                }
+            },
+            {
+                'properties': {
+                    'timestamp': '2022-01-01T06:00:00+00:00',
+                    'temperature': {'value': 20}
+                }
+            },
+            {
+                'properties': {
+                    'timestamp': '2022-01-01T12:00:00+00:00',
+                    'temperature': {'value': 5}
+                }
+            },
+            {
+                'properties': {
+                    'timestamp': '2022-01-02T00:00:00+00:00',
+                    'temperature': {'value': 15}
+                }
+            },
+            {
+                'properties': {
+                    'timestamp': '2022-01-02T06:00:00+00:00',
+                    'temperature': {'value': 5}
+                }
+            },
+            {
+                'properties': {
+                    'timestamp': '2022-01-02T12:00:00+00:00',
+                    'temperature': {'value': 10}
+                }
+            }
+        ]
+    }
+    requests.get.return_value = response_mock
+
+    # Call the function under test
+    result = get_high_low_temps_by_day('station_id')
+
+    # Assert the expected high and low temperatures for each day
+    expected_result = {
+        datetime.strptime('2022-01-01', '%Y-%m-%d').date(): {'high': 20, 'low': 5},
+        datetime.strptime('2022-01-02', '%Y-%m-%d').date(): {'high': 15, 'low': 5}
+        }
+    assert result == expected_result
+
+# Should return an empty dictionary when no temperature readings are available
+def test_return_empty_dict_no_readings(mocker):
+    # Mock the response from the API
+    mocker.patch('requests.get')
+    response_mock = mocker.Mock()
+    response_mock.json.return_value = {'features': []}
+    requests.get.return_value = response_mock
+
+    # Call the function under test
+    result = get_high_low_temps_by_day('station_id')
+
+    # Assert that the result is an empty dictionary
+    assert result == {}


### PR DESCRIPTION
Adding pytests with API mocks

Issues: one invalid test continues to fail due to `UnboundLocalError: local variable 'station_id' referenced before assignment`; continuing to investigate.